### PR TITLE
fix: handle tainted canvas in screenshots

### DIFF
--- a/src/engine/runtime/Engine.ts
+++ b/src/engine/runtime/Engine.ts
@@ -84,8 +84,16 @@ class Engine {
   async captureGameScreenshot(): Promise<string | null> {
     const gameEl = document.getElementById("game-root");
     if (!gameEl) return null;
-    const canvas = await html2canvas(gameEl);
-    return canvas.toDataURL("image/png");
+    try {
+      const canvas = await html2canvas(gameEl, {
+        useCORS: true,
+        ignoreElements: (el) => el.tagName === "CANVAS",
+      });
+      return canvas.toDataURL("image/png");
+    } catch (err) {
+      console.error("Failed to capture screenshot", err);
+      return null;
+    }
   }
 
   initVNInputHandlers(): void {


### PR DESCRIPTION
## Summary
- handle cross-origin canvas when capturing screenshots

## Testing
- `npm install`
- `npm run build sample`


------
https://chatgpt.com/codex/tasks/task_e_689733456cc0832e9b64795bcd2e1a7b