### PR TITLE
fix: save plain store state

### DIFF
--- a/src/engine/runtime/EngineSave.ts
+++ b/src/engine/runtime/EngineSave.ts
@@ -53,8 +53,8 @@ export const saveGame = (engine: Engine, slot: string, name?: string): void => {
     name: name || `Save ${slot}`,
     timestamp: new Date().toISOString(),
     screenshot: engine.lastScreenshot,
-    gameState: JSON.parse(JSON.stringify(engine.gameState)),
-    engineState: JSON.parse(JSON.stringify(engine.engineState)),
+    gameState: JSON.parse(JSON.stringify(engine.gameState.$state)),
+    engineState: JSON.parse(JSON.stringify(engine.engineState.$state)),
   };
 
   localStorage.setItem(`Save_${PROJECT_ID}_${slot}`, JSON.stringify(data));


### PR DESCRIPTION
## Summary
- save Pinia $state snapshots to avoid circular refs when saving games

## Testing
- `npm run build sample`

------
https://chatgpt.com/codex/tasks/task_e_689735dde8fc832e9882f371c8153eda