### PR TITLE
fix: load only state in loadGame

### DIFF
--- a/src/engine/runtime/EngineSave.ts
+++ b/src/engine/runtime/EngineSave.ts
@@ -22,8 +22,8 @@ export const loadGame = async (engine: Engine, slot: string): Promise<void> => {
   const data = JSON.parse(raw);
   engine.engineState.resetState();
   engine.gameState.resetGame();
-  Object.assign(engine.gameState, data.gameState);
-  Object.assign(engine.engineState, data.engineState);
+  Object.assign(engine.gameState.$state, data.gameState);
+  Object.assign(engine.engineState.$state, data.engineState);
   engine.createEventsCopy();
   engine.updateEvents();
   engine.engineState.initialized = true;


### PR DESCRIPTION
## Summary
- ensure loadGame merges saved data into store state instead of entire store

## Testing
- `npm run build sample`


------
https://chatgpt.com/codex/tasks/task_e_689739bde084832e98a18efdefd5ac83