### PR TITLE
fix: mark engine images as crossorigin

### DIFF
--- a/src/engine/core/Background.vue
+++ b/src/engine/core/Background.vue
@@ -5,13 +5,14 @@
       :src="background"
       class="object-cover w-full h-full"
       alt="Background"
+      crossorigin="anonymous"
     />
   </div>
 </template>
 
 <script setup>
-import { computed } from 'vue';
-import { engineState as useEngineState } from '@/generate/stores';
+import { computed } from "vue";
+import { engineState as useEngineState } from "@/generate/stores";
 const engineState = useEngineState();
 const background = computed(() => engineState.background);
 </script>

--- a/src/engine/core/Foreground.vue
+++ b/src/engine/core/Foreground.vue
@@ -8,12 +8,13 @@
       :src="engineState.foreground"
       class="object-contain w-full h-full"
       alt="Foreground"
+      crossorigin="anonymous"
     />
   </div>
 </template>
 
 <script setup>
-import { engineState as useEngineState } from '@/generate/stores';
+import { engineState as useEngineState } from "@/generate/stores";
 const engineState = useEngineState();
 </script>
 


### PR DESCRIPTION
## Summary
- mark background and foreground image tags with `crossorigin="anonymous"` to support html2canvas screenshots

## Testing
- `npm run build sample`


------
https://chatgpt.com/codex/tasks/task_e_68974db169a4832e8ae78a4ac94f08cb