### PR TITLE
fix: drop save screenshots and update menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "chokidar-cli": "^3.0.0",
         "concurrently": "^9.2.0",
         "fs-extra": "^11.3.0",
-        "html2canvas": "^1.4.1",
         "monaco-editor-vue3": "^0.1.10",
         "serve-static": "^2.2.0",
         "typescript": "^5.9.2",
@@ -1169,16 +1168,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
-    "node_modules/base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1720,16 +1709,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css-line-break": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
-      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "utrie": "^1.0.2"
-      }
-    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2148,20 +2127,6 @@
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
       "license": "MIT"
-    },
-    "node_modules/html2canvas": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
-      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-line-break": "^2.1.0",
-        "text-segmentation": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -3402,16 +3367,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/text-segmentation": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
-      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "utrie": "^1.0.2"
-      }
-    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -3561,16 +3516,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/utrie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
-      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "base64-arraybuffer": "^1.0.2"
-      }
     },
     "node_modules/vite": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "chokidar-cli": "^3.0.0",
     "concurrently": "^9.2.0",
     "fs-extra": "^11.3.0",
-    "html2canvas": "^1.4.1",
     "monaco-editor-vue3": "^0.1.10",
     "serve-static": "^2.2.0",
     "typescript": "^5.9.2",

--- a/src/engine/menu/SaveLoadMenu.vue
+++ b/src/engine/menu/SaveLoadMenu.vue
@@ -20,7 +20,7 @@
         class="bg-gray-900 text-white rounded-lg w-full max-w-3xl p-4 flex flex-col items-center"
       >
         <h2 class="text-xl font-bold mb-4 text-center">
-          {{ mode === 'save' ? 'Save Game' : 'Load Game' }}
+          {{ mode === "save" ? "Save Game" : "Load Game" }}
         </h2>
         <div class="grid grid-cols-4 grid-rows-2 gap-4 mb-6">
           <div
@@ -28,16 +28,6 @@
             :key="slot"
             class="bg-gray-800 rounded shadow p-2 flex flex-col items-center"
           >
-            <div
-              class="w-full h-24 bg-gray-700 flex items-center justify-center mb-2 rounded"
-            >
-              <img
-                v-if="saves[slot] && saves[slot].screenshot"
-                :src="saves[slot].screenshot"
-                class="object-cover w-full h-full rounded"
-              />
-              <span v-else class="text-gray-400">No Screenshot</span>
-            </div>
             <div class="w-full text-center mb-1">
               <span class="font-semibold">
                 {{ saves[slot]?.name || `Slot ${slot}` }}
@@ -99,13 +89,13 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue';
+import { ref, computed, onMounted } from "vue";
 import {
   engineState as useEngineState,
   engineStateEnum as ENGINE_STATES,
-} from '@/generate/stores';
+} from "@/generate/stores";
 const engineState = useEngineState();
-import { PROJECT_ID } from '@/generate/components';
+import { PROJECT_ID } from "@/generate/components";
 
 const slotsPerPage = 8;
 const maxSlots = 24;
@@ -114,20 +104,20 @@ const saves = ref({});
 const saveNames = ref({});
 
 const mode = computed(() => {
-  if (engineState.state === ENGINE_STATES.SAVE) return 'save';
-  if (engineState.state === ENGINE_STATES.LOAD) return 'load';
-  return 'save'; // fallback
+  if (engineState.state === ENGINE_STATES.SAVE) return "save";
+  if (engineState.state === ENGINE_STATES.LOAD) return "load";
+  return "save"; // fallback
 });
 
 const visibleSlots = computed(() => {
   const start = page.value * slotsPerPage + 1;
   return Array.from({ length: slotsPerPage }, (_, i) => start + i).filter(
-    (n) => n <= maxSlots
+    (n) => n <= maxSlots,
   );
 });
 
 function formatDate(timestamp) {
-  if (!timestamp) return '';
+  if (!timestamp) return "";
   return new Date(timestamp).toLocaleString();
 }
 
@@ -139,10 +129,10 @@ function loadSaves() {
       try {
         const data = JSON.parse(raw);
         saves.value[i] = data;
-        saveNames.value[i] = data.name || '';
+        saveNames.value[i] = data.name || "";
       } catch {}
     } else {
-      saveNames.value[i] = '';
+      saveNames.value[i] = "";
     }
   }
 }
@@ -170,8 +160,8 @@ onMounted(loadSaves);
 
 const menuBgStyle = {
   backgroundImage: "url('assets/images/background/menu.png')",
-  backgroundSize: 'cover',
-  backgroundPosition: 'center',
+  backgroundSize: "cover",
+  backgroundPosition: "center",
 };
 </script>
 

--- a/src/engine/runtime/Engine.ts
+++ b/src/engine/runtime/Engine.ts
@@ -4,7 +4,6 @@ import {
   EngineSave,
   VNInterruptError,
 } from "@/generate/runtime";
-import html2canvas from "html2canvas";
 import { engineStateEnum as ENGINE_STATES } from "@/generate/stores";
 import type { GameState, EngineState, VNEvent } from "./types";
 
@@ -12,7 +11,6 @@ class Engine {
   gameState: GameState;
   engineState: EngineState;
   awaiterResult: ((value: any) => void) | null;
-  lastScreenshot: string | null;
   replayMode: boolean;
   targetStep: number;
   eventCache: Record<
@@ -24,7 +22,6 @@ class Engine {
     this.gameState = gameState;
     this.engineState = engineState;
     this.awaiterResult = null;
-    this.lastScreenshot = null;
     this.replayMode = false;
     this.targetStep = 0;
     this.eventCache = {};
@@ -81,23 +78,8 @@ class Engine {
   }
   // #endregion
 
-  async captureGameScreenshot(): Promise<string | null> {
-    const gameEl = document.getElementById("game-root");
-    if (!gameEl) return null;
-    try {
-      const canvas = await html2canvas(gameEl, {
-        useCORS: true,
-        ignoreElements: (el) => el.tagName === "CANVAS",
-      });
-      return canvas.toDataURL("image/png");
-    } catch (err) {
-      console.error("Failed to capture screenshot", err);
-      return null;
-    }
-  }
-
   initVNInputHandlers(): void {
-    window.addEventListener("keydown", async (e) => {
+    window.addEventListener("keydown", (e) => {
       if (e.key === "Escape") {
         if (
           this.engineState.initialized &&
@@ -105,7 +87,6 @@ class Engine {
         ) {
           this.engineState.state = ENGINE_STATES.RUNNING;
         } else {
-          this.lastScreenshot = await this.captureGameScreenshot();
           this.engineState.state = ENGINE_STATES.MENU;
         }
       } else if (e.key === "Space" || e.key === "ArrowRight") {

--- a/src/engine/runtime/EngineSave.ts
+++ b/src/engine/runtime/EngineSave.ts
@@ -52,7 +52,6 @@ export const saveGame = (engine: Engine, slot: string, name?: string): void => {
   const data = {
     name: name || `Save ${slot}`,
     timestamp: new Date().toISOString(),
-    screenshot: engine.lastScreenshot,
     gameState: JSON.parse(JSON.stringify(engine.gameState.$state)),
     engineState: JSON.parse(JSON.stringify(engine.engineState.$state)),
   };


### PR DESCRIPTION
## Summary
- strip screenshot data from save routine and game engine, removing html2canvas dependency
- simplify save/load menu UI that previously displayed screenshots

## Testing
- `npm install`
- `npm run build sample`


------
https://chatgpt.com/codex/tasks/task_e_689768db2648832ead64bff366d1a81e