### PR TITLE
fix: locate events by id when loading saves

### DIFF
--- a/src/engine/runtime/Engine.ts
+++ b/src/engine/runtime/Engine.ts
@@ -173,6 +173,16 @@ class Engine {
   }
 
   findEventById(eventId: string): VNEvent | null {
+    for (const location in this.eventCache) {
+      const cache = this.eventCache[location];
+      for (const list of ["unlocked", "locked", "notReady"] as const) {
+        const found = cache[list].find((ev) => ev.id === eventId);
+        if (found) {
+          return found;
+        }
+      }
+    }
+    console.warn(`Event with id '${eventId}' not found`);
     return null;
   }
 


### PR DESCRIPTION
## Summary
- search event caches to retrieve event by id

## Testing
- `npm install`
- `npm run build sample`


------
https://chatgpt.com/codex/tasks/task_e_68976d372db4832e8c62b0db753d4709