### PR TITLE
chore: require Node 22 LTS

### DIFF
--- a/.github/workflows/deploy-sample.yml
+++ b/.github/workflows/deploy-sample.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ These instructions apply to the entire repository.
 
 ## Setup & Development
 
-- Use Node.js ≥18 (match the version used in CI or `.nvmrc` if present).
+- Use Node.js 22 LTS (match the version used in CI or `.nvmrc` if present).
 - Install dependencies with `npm install`.
 - Run `npm run build sample` to ensure the project builds without errors before committing.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ projects/                # All VN projects
 
 ### Prerequisites
 
-- Node.js (v16 or later recommended)
+- Node.js 22 LTS (required by Vite 7)
 - npm or yarn
 
 ### Installation
@@ -103,12 +103,12 @@ Example - Custom game state:
 
 ```javascript
 // projects/my-game/stores/gameState.js
-import { defineStore } from 'pinia';
+import { defineStore } from "pinia";
 
-export default defineStore('gameState', {
+export default defineStore("gameState", {
   state: () => ({
     player: {
-      name: '',
+      name: "",
       health: 100,
       inventory: [],
     },
@@ -125,11 +125,11 @@ Events are organized by location in the `events/` directory:
 ```javascript
 // projects/my-game/events/bedroom/wake-up.js
 export default {
-  id: 'wake_up',
-  name: 'Wake Up Event',
+  id: "wake_up",
+  name: "Wake Up Event",
   conditions: (state) => state.chapter === 1 && !state.flags.wokeUp,
   async execute(engine, state) {
-    await engine.showText('You slowly open your eyes...');
+    await engine.showText("You slowly open your eyes...");
     state.flags.wokeUp = true;
   },
 };

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "scripts": {
     "add-project": "node scripts/add-project.cjs",
     "dev": "node scripts/dev.cjs",


### PR DESCRIPTION
## Summary
- update docs to require Node.js 22 LTS
- add Node.js 22 engine constraint and use in CI

## Testing
- `npm run build sample`


------
https://chatgpt.com/codex/tasks/task_e_68976ea6a38c832ea2b7a2e6be4899c1