### PR TITLE
feat: implement choice UI and intro loop

### DIFF
--- a/projects/sample/events/start/intro.ts
+++ b/projects/sample/events/start/intro.ts
@@ -10,16 +10,25 @@ const intro: VNEvent = {
     engine.setForeground("assets/images/background/intro/hall.png");
     await engine.showText("Welcome to sample!");
     await engine.showText("This is your first event.");
-    const choice = await engine.showChoices([
-      { text: "Start the adventure", id: "start" },
-      { text: "Learn more", id: "learn" },
-    ]);
-    if (choice === "learn") {
-      await engine.showText("VueVN is a visual novel engine built with Vue 3.");
-      await engine.showText(
-        "You can create your own stories by adding events and assets.",
-      );
+    let choice = "";
+    while (choice !== "start") {
+      choice = await engine.showChoices([
+        { text: "Start the adventure", id: "start" },
+        { text: "Learn more", id: "learn" },
+      ]);
+
+      if (choice === "learn") {
+        await engine.showText(
+          "VueVN is a visual novel engine built with Vue 3.",
+        );
+        await engine.showText(
+          "You can create your own stories by adding events and assets.",
+        );
+        await engine.showChoices([{ text: "Return", id: "return" }]);
+      }
     }
+
+    await engine.showText("Great! Let's begin your adventure.");
     state.flags.introSeen = true;
     state.location = "bedroom";
   },

--- a/src/engine/core/Choice.vue
+++ b/src/engine/core/Choice.vue
@@ -1,12 +1,13 @@
 <template>
   <div
-    v-if="engineState.choiceShow"
+    v-if="engineState.choices && engineState.choices.length"
     class="absolute bottom-24 left-0 w-full z-50 pointer-events-auto"
   >
     <div class="flex flex-col items-center space-y-2 max-w-2xl mx-auto">
       <button
         v-for="choice in engineState.choices"
         :key="choice.id"
+        @click="select(choice.id)"
         class="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded shadow"
       >
         {{ choice.text }}
@@ -15,9 +16,15 @@
   </div>
 </template>
 
-<script setup>
-import { engineState as useEngineState } from '@/generate/stores';
+<script setup lang="ts">
+import Engine from "@/engine/runtime/Engine";
+import { engineState as useEngineState } from "@/generate/stores";
+
 const engineState = useEngineState();
+
+function select(id: string): void {
+  Engine.getInstance()?.resolveAwaiter(id);
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- add selectable choice component to resolve engine awaiters
- allow intro event to loop with a return option until start is chosen

## Testing
- `npm run build sample`


------
https://chatgpt.com/codex/tasks/task_e_6897869553f4832ea3f570210ccf209a