### PR TITLE
fix: reset replay mode after event replay

### DIFF
--- a/src/engine/runtime/EngineAPI.ts
+++ b/src/engine/runtime/EngineAPI.ts
@@ -16,8 +16,11 @@ export const showText = async (
   from = "engine",
 ): Promise<void> => {
   engine.engineState.currentStep++;
-  if (engine.replayMode && engine.engineState.currentStep < engine.targetStep) {
-    return;
+  if (engine.replayMode) {
+    if (engine.engineState.currentStep < engine.targetStep) {
+      return;
+    }
+    engine.replayMode = false;
   }
 
   engine.engineState.dialogue = {

--- a/src/engine/runtime/EngineSave.ts
+++ b/src/engine/runtime/EngineSave.ts
@@ -44,6 +44,7 @@ const startEventReplay = async (engine: Engine): Promise<void> => {
     console.debug("Starting event replay for:", event.id);
     await engine.handleEvent(event);
   }
+  engine.replayMode = false;
   engine.engineState.state = ENGINE_STATES.RUNNING;
 };
 


### PR DESCRIPTION
## Summary
- Reset replay mode after replaying an event
- Turn off replay mode once target step is reached during text playback

## Testing
- `npm run build sample`


------
https://chatgpt.com/codex/tasks/task_e_68978da8a034832e8d7e0f0a463685fc