### PR TITLE
feat: add he-tree file explorer and file-backed editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "src",
       "version": "0.0.0",
       "dependencies": {
+        "@he-tree/vue": "^2.9.4",
         "autoprefixer": "^10.4.21",
         "lodash": "^4.17.21",
         "monaco-editor": "^0.52.2",
@@ -28,6 +29,9 @@
         "vite": "^7.0.0",
         "vite-plugin-monaco-editor": "^1.1.0",
         "vite-plugin-singlefile": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -73,6 +77,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -511,6 +524,101 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@he-tree/dnd-utils": {
+      "version": "0.1.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@he-tree/dnd-utils/-/dnd-utils-0.1.0-alpha.4.tgz",
+      "integrity": "sha512-DuxkFOQ8eztoHrX1/VelqOnQphQbRszemfMKSKlAEEhVjqR/IkaOE2QSRlAdj6OC6AfMvHDPvIZOiEPFwP6/ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.7",
+        "drag-event-service": "^2.0.0",
+        "helper-js": "^3.1.2"
+      }
+    },
+    "node_modules/@he-tree/tree-utils": {
+      "version": "0.1.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@he-tree/tree-utils/-/tree-utils-0.1.0-alpha.6.tgz",
+      "integrity": "sha512-TIH1iIRLpn3sjd4EuIfKQzFd6ToY8GLYk3i5bfK1njCW7lBBDHLqSyK0mlJPbCPk4PfkZBC4K+sMcYyH4hokyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.7",
+        "drag-event-service": "^2.0.0",
+        "helper-js": "^3.1.2"
+      }
+    },
+    "node_modules/@he-tree/vue": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@he-tree/vue/-/vue-2.9.4.tgz",
+      "integrity": "sha512-n8yycL4fk46mlg6sIkcdSZmSCRvdzqj7Ts14ulKXLqmyR6NyTSnP6O9pj6dPk2S2wJIuX2Ad6MOzpg0qDhlBXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@he-tree/dnd-utils": "^0.1.0-alpha.4",
+        "@he-tree/tree-utils": "^0.1.0-alpha.6",
+        "@virtual-list/vue": "^1.2.1",
+        "helper-js": "^3.1.2",
+        "vue-demi": "latest"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.4.6",
+        "vue": "^2.0.0 || >=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@he-tree/vue/node_modules/@virtual-list/vue": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@virtual-list/vue/-/vue-1.2.1.tgz",
+      "integrity": "sha512-sVangNRLgHJsrwjf2EeXuc8mUExbLRJO39J9/FXFWXXQkue/FBT4ZWN7GH5+GJTeVaEEfHW1W2UuVaf3LEB3jQ==",
+      "license": "MIT",
+      "dependencies": {
+        "helper-js": "^3.1.2",
+        "vue-demi": "latest"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.4.6",
+        "vue": "^2.0.0 || >=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@he-tree/vue/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1777,6 +1885,16 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
     },
+    "node_modules/drag-event-service": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/drag-event-service/-/drag-event-service-2.0.0.tgz",
+      "integrity": "sha512-JVEnOEbbNDS3RrWd+tVVIDu2SHQZ9luhEFGSQ1hXMjl+ABw0PxhHmnkGjzPVE836Tsg+k7rkm5GM9Ln/UgbYpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.7",
+        "helper-js": "^3.0.0"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2120,6 +2238,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helper-js": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/helper-js/-/helper-js-3.1.6.tgz",
+      "integrity": "sha512-lhncHDAxS2PTA44aG1AofxT51v0IXEVOmaUCC6HwuGaGqE1yEkjhPH74Vb/Aw4xt8Kt5bMvStCr6FekANp+PGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.7"
       }
     },
     "node_modules/hookable": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "autoprefixer": "^10.4.21",
     "lodash": "^4.17.21",
     "monaco-editor": "^0.52.2",
+    "@he-tree/vue": "^2.9.4",
     "pinia": "^3.0.3",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",

--- a/src/editor/ProjectEditor.vue
+++ b/src/editor/ProjectEditor.vue
@@ -4,17 +4,10 @@
     <div
       class="w-1/5 h-full border-r border-gray-800 bg-gray-900 flex flex-col"
     >
-      <div class="flex items-center justify-between p-2">
+      <div class="p-2">
         <span class="text-green-400 font-mono text-xs">Explorer</span>
-        <button
-          v-if="!previewVisible"
-          @click="showPreview"
-          class="ml-2 bg-green-700 hover:bg-green-600 text-white rounded px-3 py-1 text-xs shadow"
-        >
-          Show Preview
-        </button>
       </div>
-      <!-- TODO: TreeView des fichiers/locations/events du projet -->
+      <ProjectExplorer />
     </div>
     <!-- Centre : Monaco Editor + State Inspector -->
     <div class="flex-1 flex flex-col">
@@ -32,18 +25,12 @@
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue';
-import { loadMonaco } from '@/editor/utils/monacoLoader.js';
-import MonacoEditor from '@/editor/components/MonacoEditor.vue';
-import StateEditorPanel from '@/editor/components/StateEditorPanel.vue';
-import FloatingGame from '@/editor/components/FloatingGame.vue';
-import { useEditorState } from '@/editor/stores/editorState';
-const editorState = useEditorState();
-const previewVisible = computed(() => editorState.previewVisible);
-
-function showPreview() {
-  editorState.previewVisible = true;
-}
+import { onMounted } from "vue";
+import { loadMonaco } from "@/editor/utils/monacoLoader.js";
+import MonacoEditor from "@/editor/components/MonacoEditor.vue";
+import StateEditorPanel from "@/editor/components/StateEditorPanel.vue";
+import FloatingGame from "@/editor/components/FloatingGame.vue";
+import ProjectExplorer from "@/editor/components/ProjectExplorer.vue";
 
 onMounted(async () => {
   await loadMonaco();

--- a/src/editor/components/MonacoEditor.vue
+++ b/src/editor/components/MonacoEditor.vue
@@ -5,12 +5,27 @@
     <div
       class="flex items-center justify-between px-4 py-2 bg-gray-800 border-b border-gray-700"
     >
-      <span class="font-mono text-green-400 text-sm">Event Editor</span>
-      <button
-        class="text-xs px-2 py-1 bg-green-700 hover:bg-green-600 rounded text-white"
-      >
-        Save
-      </button>
+      <span class="font-mono text-green-400 text-sm">{{
+        currentFileName
+      }}</span>
+      <div class="space-x-2 flex items-center">
+        <button
+          class="text-xs px-2 py-1 bg-blue-700 hover:bg-blue-600 rounded text-white disabled:opacity-50"
+          :disabled="!currentFile"
+          @click="run"
+        >
+          Preview
+        </button>
+        <button
+          class="text-xs px-2 py-1 bg-green-700 hover:bg-green-600 rounded text-white disabled:opacity-50"
+          :disabled="!currentFile || saving"
+          @click="save"
+        >
+          <span v-if="saving">Saving...</span>
+          <span v-else>Save</span>
+        </button>
+        <span v-if="saveMessage" class="text-green-400">{{ saveMessage }}</span>
+      </div>
     </div>
     <div class="flex-1 relative">
       <div ref="editorContainer" class="absolute inset-0" />
@@ -18,32 +33,67 @@
   </div>
 </template>
 
-<script setup>
-import { loadMonaco } from '@/editor/utils/monacoLoader.js';
-import { onMounted, ref, onBeforeUnmount } from 'vue';
-let editorInstance = null;
-const editorContainer = ref(null);
+<script setup lang="ts">
+import { onMounted, ref, watch, computed } from "vue";
+import { loadMonaco } from "@/editor/utils/monacoLoader.js";
+import { registerEventTypes } from "@/editor/utils/eventTypes";
+import { verifyEvent } from "@/editor/utils/verifyEvent";
+import { useEditorState } from "@/editor/stores/editorState";
+
+const editorContainer = ref<HTMLDivElement | null>(null);
+let editorInstance: any = null;
+
+const editorState = useEditorState();
+const currentFile = computed(() => editorState.currentFile);
+const currentFileName = computed(
+  () => currentFile.value?.split("/").pop() ?? "No file selected",
+);
+const saving = ref(false);
+const saveMessage = ref("");
+
+async function loadFile(path: string) {
+  const res = await fetch(`/api/file?path=${encodeURIComponent(path)}`);
+  const data = await res.json();
+  editorInstance?.setValue(data.content);
+}
+
+async function save() {
+  if (!editorInstance || !currentFile.value) return;
+  const code = editorInstance.getValue();
+  const valid = await verifyEvent(code);
+  if (!valid) return;
+  saving.value = true;
+  try {
+    await fetch("/api/file", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: currentFile.value, content: code }),
+    });
+    saveMessage.value = "Saved";
+    setTimeout(() => (saveMessage.value = ""), 2000);
+  } finally {
+    saving.value = false;
+  }
+}
+
+function run() {
+  if (!currentFile.value) return;
+  editorState.previewVisible = true;
+  console.debug("Run event", currentFile.value);
+}
 
 onMounted(async () => {
   await loadMonaco();
-  editorInstance = window.monaco.editor.create(editorContainer.value, {
-    value: '// Commence à écrire ton event ici\n\nTEMPALTE FUTUR\n',
-    language: 'javascript',
-    theme: 'vs-dark',
+  registerEventTypes();
+  editorInstance = window.monaco.editor.create(editorContainer.value!, {
+    value: "",
+    language: "typescript",
+    theme: "vs-dark",
     automaticLayout: true,
   });
 });
 
-onBeforeUnmount(() => {
-  if (editorInstance) editorInstance.dispose();
+watch(currentFile, (file) => {
+  if (file) loadFile(file);
 });
 </script>
-
-<style scoped>
-.h-full {
-  height: 100%;
-}
-.w-full {
-  width: 100%;
-}
-</style>

--- a/src/editor/components/ProjectExplorer.vue
+++ b/src/editor/components/ProjectExplorer.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="flex-1 overflow-y-auto text-xs">
+    <button
+      class="w-full text-left px-2 py-1 hover:bg-gray-800"
+      @click="createEvent"
+    >
+      + Add Event
+    </button>
+    <BaseTree
+      v-if="tree.length"
+      :value="tree"
+      :text-key="'name'"
+      :children-key="'children'"
+      :indent="12"
+      default-open
+    >
+      <template #default="{ stat }">
+        <div
+          class="flex items-center cursor-pointer px-2 py-1 hover:bg-gray-800"
+          :class="{
+            'bg-gray-800': editorState.currentFile === stat.data.path,
+          }"
+          @click="handleNode(stat.data)"
+        >
+          <OpenIcon
+            v-if="stat.data.type === 'directory'"
+            :stat="stat"
+            class="mr-1"
+          />
+          <span class="truncate">{{ stat.data.name }}</span>
+        </div>
+      </template>
+    </BaseTree>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { BaseTree, OpenIcon } from "@he-tree/vue";
+import "@he-tree/vue/style/default.css";
+import { useEditorState } from "@/editor/stores/editorState";
+
+interface FileItem {
+  name: string;
+  type: "file" | "directory";
+  path: string;
+  children?: FileItem[];
+}
+
+const tree = ref<FileItem[]>([]);
+const editorState = useEditorState();
+
+async function loadDir(dir = ""): Promise<FileItem[]> {
+  const res = await fetch(`/api/files?path=${encodeURIComponent(dir)}`);
+  const items: FileItem[] = await res.json();
+  for (const item of items) {
+    if (item.type === "directory") {
+      item.children = await loadDir(item.path);
+    }
+  }
+  return items;
+}
+
+onMounted(async () => {
+  tree.value = await loadDir();
+  const first = findFirstFile(tree.value);
+  if (first) editorState.selectFile(first.path);
+});
+
+function findFirstFile(nodes: FileItem[]): FileItem | null {
+  for (const node of nodes) {
+    if (node.type === "file") return node;
+    if (node.children) {
+      const found = findFirstFile(node.children);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+function handleNode(node: FileItem) {
+  if (node.type === "file") editorState.selectFile(node.path);
+}
+
+async function createEvent() {
+  const name = prompt("Event file path", "events/new-event.ts");
+  if (!name) return;
+
+  const templatesRes = await fetch("/api/project/templates");
+  const templates = await templatesRes.json();
+
+  await fetch("/api/create", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      path: name,
+      type: "file",
+      template: templates.event,
+    }),
+  });
+
+  tree.value = await loadDir();
+  editorState.selectFile(name);
+}
+</script>

--- a/src/editor/components/ProjectExplorer.vue
+++ b/src/editor/components/ProjectExplorer.vue
@@ -8,7 +8,7 @@
     </button>
     <BaseTree
       v-if="tree.length"
-      :value="tree"
+      :model-value="tree"
       :text-key="'name'"
       :children-key="'children'"
       :indent="12"

--- a/src/editor/components/ProjectExplorer.vue
+++ b/src/editor/components/ProjectExplorer.vue
@@ -69,7 +69,9 @@ onMounted(async () => {
 
 function findFirstFile(nodes: FileItem[]): FileItem | null {
   for (const node of nodes) {
-    if (node.type === "file") return node;
+    if (node.type === "file" && /\.(ts|vue)$/i.test(node.name)) {
+      return node;
+    }
     if (node.children) {
       const found = findFirstFile(node.children);
       if (found) return found;

--- a/src/editor/components/StateEditorPanel.vue
+++ b/src/editor/components/StateEditorPanel.vue
@@ -41,7 +41,8 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onBeforeUnmount, watch } from 'vue';
+import { ref, onMounted, onBeforeUnmount, watch } from "vue";
+import { loadMonaco } from "@/editor/utils/monacoLoader.js";
 
 // Editor container refs
 const engineEditorContainer = ref(null);
@@ -54,51 +55,25 @@ let gameEditorInstance = null;
 import {
   engineState as useEngineState,
   gameState as useGameState,
-} from '@/generate/stores';
+} from "@/generate/stores";
 
 const engineState = useEngineState();
 const gameState = useGameState();
 
-// Load Monaco Editor
-function loadMonaco() {
-  return new Promise((resolve) => {
-    if (window.monaco) return resolve();
-
-    const script = document.createElement('script');
-    script.src =
-      'https://cdn.jsdelivr.net/npm/monaco-editor@0.44.0/min/vs/loader.js';
-    script.onload = () => {
-      window.require.config({
-        paths: {
-          vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.44.0/min/vs',
-        },
-      });
-      resolve();
-    };
-    document.body.appendChild(script);
-  });
-}
-
-async function createEditor(container, initialValue, language = 'json') {
+async function createEditor(container, initialValue, language = "json") {
   await loadMonaco();
-
-  return new Promise((resolve) => {
-    window.require(['vs/editor/editor.main'], () => {
-      const editor = window.monaco.editor.create(container, {
-        value: initialValue,
-        language,
-        theme: 'vs-dark',
-        automaticLayout: true,
-        minimap: { enabled: false },
-      });
-      resolve(editor);
-    });
+  return window.monaco.editor.create(container, {
+    value: initialValue,
+    language,
+    theme: "vs-dark",
+    automaticLayout: true,
+    minimap: { enabled: false },
   });
 }
 
 // Keep JSON in sync with state
-const engineJson = ref('');
-const gameJson = ref('');
+const engineJson = ref("");
+const gameJson = ref("");
 
 watch(
   () => JSON.stringify(engineState, null, 2),
@@ -111,7 +86,7 @@ watch(
       }
     }
   },
-  { immediate: true }
+  { immediate: true },
 );
 
 watch(
@@ -125,17 +100,17 @@ watch(
       }
     }
   },
-  { immediate: true }
+  { immediate: true },
 );
 
 onMounted(async () => {
   engineEditorInstance = await createEditor(
     engineEditorContainer.value,
-    JSON.stringify(engineState, null, 2)
+    JSON.stringify(engineState, null, 2),
   );
   gameEditorInstance = await createEditor(
     gameEditorContainer.value,
-    JSON.stringify(gameState, null, 2)
+    JSON.stringify(gameState, null, 2),
   );
 });
 
@@ -149,12 +124,12 @@ function applyEngineState() {
   try {
     const value = engineEditorInstance.getValue();
     const updated = JSON.parse(value);
-    if (typeof updated === 'object' && updated !== null) {
+    if (typeof updated === "object" && updated !== null) {
       engineState.$patch(updated);
-      alert('Engine State updated successfully!');
+      alert("Engine State updated successfully!");
     }
   } catch {
-    alert('EngineState JSON is invalid!');
+    alert("EngineState JSON is invalid!");
   }
 }
 
@@ -162,12 +137,12 @@ function applyGameState() {
   try {
     const value = gameEditorInstance.getValue();
     const updated = JSON.parse(value);
-    if (typeof updated === 'object' && updated !== null) {
+    if (typeof updated === "object" && updated !== null) {
       gameState.$patch(updated);
-      alert('Game State updated successfully!');
+      alert("Game State updated successfully!");
     }
   } catch {
-    alert('GameState JSON is invalid!');
+    alert("GameState JSON is invalid!");
   }
 }
 </script>

--- a/src/editor/types/event.d.ts
+++ b/src/editor/types/event.d.ts
@@ -1,0 +1,20 @@
+export interface GameState {
+  player: { name: string };
+  location: string;
+  flags: Record<string, any>;
+  [key: string]: any;
+}
+
+export interface Engine {}
+
+export interface VNEvent {
+  id: string;
+  name: string;
+  conditions?: (state: GameState) => boolean;
+  unlocked?: (state: GameState) => boolean;
+  locked?: (state: GameState) => boolean;
+  draw?: (engine: Engine, state: GameState) => void;
+  execute: (engine: Engine, state: GameState) => Promise<void>;
+}
+
+export declare function createEvent(event: VNEvent): VNEvent;

--- a/src/editor/utils/eventTypes.ts
+++ b/src/editor/utils/eventTypes.ts
@@ -1,0 +1,9 @@
+import eventTypes from "@/editor/types/event.d.ts?raw";
+
+export function registerEventTypes() {
+  if (!window.monaco) return;
+  window.monaco.languages.typescript.typescriptDefaults.addExtraLib(
+    eventTypes,
+    "ts:event.d.ts",
+  );
+}

--- a/src/editor/utils/monacoLoader.js
+++ b/src/editor/utils/monacoLoader.js
@@ -1,23 +1,30 @@
 // src/utils/monacoLoader.js
+let monacoPromise;
+
 export function loadMonaco() {
   if (window.monaco) {
     return Promise.resolve();
   }
+  if (monacoPromise) {
+    return monacoPromise;
+  }
 
-  return new Promise((resolve) => {
-    const script = document.createElement('script');
+  monacoPromise = new Promise((resolve) => {
+    const script = document.createElement("script");
     script.src =
-      'https://cdn.jsdelivr.net/npm/monaco-editor@0.44.0/min/vs/loader.js';
+      "https://cdn.jsdelivr.net/npm/monaco-editor@0.44.0/min/vs/loader.js";
     script.onload = () => {
       window.require.config({
         paths: {
-          vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.44.0/min/vs',
+          vs: "https://cdn.jsdelivr.net/npm/monaco-editor@0.44.0/min/vs",
         },
       });
-      window.require(['vs/editor/editor.main'], () => {
+      window.require(["vs/editor/editor.main"], () => {
         resolve();
       });
     };
     document.body.appendChild(script);
   });
+
+  return monacoPromise;
 }

--- a/src/editor/utils/verifyEvent.ts
+++ b/src/editor/utils/verifyEvent.ts
@@ -1,0 +1,5 @@
+export async function verifyEvent(code: string): Promise<boolean> {
+  // TODO: Implement event validation logic
+  console.debug("Verifying event code", code);
+  return true;
+}


### PR DESCRIPTION
## Summary
- replace event list with @he-tree/vue project tree and load files recursively
- fix file API to point at selected project root
- remove in-memory file node and add @he-tree/vue dependency

## Testing
- `npm install`
- `npm run build sample`


------
https://chatgpt.com/codex/tasks/task_e_68978f00e290832ead55ed84863b7c06