### PR TITLE
fix: open first ts or vue file in editor

### DIFF
--- a/src/editor/components/ProjectExplorer.vue
+++ b/src/editor/components/ProjectExplorer.vue
@@ -69,7 +69,9 @@ onMounted(async () => {
 
 function findFirstFile(nodes: FileItem[]): FileItem | null {
   for (const node of nodes) {
-    if (node.type === "file") return node;
+    if (node.type === "file" && /\.(ts|vue)$/i.test(node.name)) {
+      return node;
+    }
     if (node.children) {
       const found = findFirstFile(node.children);
       if (found) return found;


### PR DESCRIPTION
## Summary
- ensure ProjectExplorer only selects initial TS/Vue files

## Testing
- `npm install`
- `npm run build sample`


------
https://chatgpt.com/codex/tasks/task_e_6897a9fbbbb4832e9fed1fdd4098c575